### PR TITLE
Update state machine interpreter and version number

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "stateforward"
-version = "0.2.5"
+version = "0.2.6"
 description = ""
 authors = ["leonwilly101 <leonwilly101@gmail.com>"]
 readme = "README.md"

--- a/stateforward/state_machine/interpreters/asynchronous/state_machine_interpreter.py
+++ b/stateforward/state_machine/interpreters/asynchronous/state_machine_interpreter.py
@@ -262,11 +262,11 @@ class AsyncStateMachineInterpreter(AsyncBehaviorInterpreter[T]):
             task = self.exec_event_entry(event)
             if task is not None:
                 tasks.append(task)
-
-        self.push(
-            transition.events,
-            self.wait(*tasks),
-        )
+        if tasks:
+            self.push(
+                transition.events,
+                self.wait(*tasks),
+            )
 
     async def exec_state_entry(
         self, state: elements.State, event: elements.Event, kind: elements.EntryKind


### PR DESCRIPTION
Modified state machine interpreter to only push tasks when present and updated the project version from 0.2.5 to 0.2.6. The changes in the interpreter improve task management by avoiding unnecessary push operations when there are no tasks, contributing to better efficiency. The version update reflects these changes and other recent code refactorings.